### PR TITLE
Added cctl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contrib/cctl"]
+	path = contrib/cctl
+	url = https://github.com/bmofa/cctl

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ $(BUILDPREFIX)/%.o: src/%.c
 install:
 	install -m 755 -D $(BUILDPREFIX)/$(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
 	install -m 755 -D contrib/custardctl.py $(DESTDIR)$(PREFIX)/bin/custardctl
+	cd contrib/cctl
+	make install
 #	install -m 644 -D man/custard.man $(DESTDIR)$(MANPREFIX)/man1/custard.1
 
 clean:


### PR DESCRIPTION
Added [cctl](https://github.com/bmofa/cctl) as a submodule to custard. 
Added the installation of cctl to the main `make install` target.