### PR TITLE
Modified Makefile as stated in #21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LD  = $(CC)
 
 CFLAGS   = -Wall -Wextra -pedantic -std=c99 -O2
 CPPFLAGS = -MD -MP -D_POSIX_C_SOURCE=200809L
-LDFLAGS  = -lxcb -xcb-ewmh -lxcb-icccm -lxcb-util -lconfig
+LDFLAGS  = -lxcb -lxcb-ewmh -lxcb-icccm -lxcb-util -lconfig
 
 PREFIX    = /usr/local
 BINPREFIX = $(PREFIX)/bin


### PR DESCRIPTION
Has all the advantages stated in #21 (more consistency and a little cleaner, uninstall target, VPATH driven out ot source builds).

#### In source build

1. `make`

#### Out of source build

1. `mkdir $builddir`
2. `cp Makefile $builddir`
3. `cd $builddir`
4. `make SRCPREFIX=/path/to/custard` (`SRCPREFIX=..` in most cases)